### PR TITLE
fix triton install issue based on whisper updates

### DIFF
--- a/package/whisper-at/requirements.txt
+++ b/package/whisper-at/requirements.txt
@@ -4,3 +4,4 @@ torch
 tqdm
 more-itertools
 tiktoken==0.3.3
+triton>=2.0.0,<3;platform_machine=="x86_64" and sys_platform=="linux" or sys_platform=="linux2"

--- a/package/whisper-at/setup.py
+++ b/package/whisper-at/setup.py
@@ -1,13 +1,13 @@
-import os
 import platform
 import sys
+from pathlib import Path
 
 import pkg_resources
 from setuptools import find_packages, setup
 
 requirements = []
 if sys.platform.startswith("linux") and platform.machine() == "x86_64":
-    requirements.append("triton==2.0.0")
+    requirements.append("triton>=2.0.0,<3")
 
 setup(
     name="whisper-at",
@@ -22,11 +22,10 @@ setup(
     url="https://github.com/YuanGongND/whisper-at",
     license="BSD",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=requirements
-    + [
+    install_requires=[
         str(r)
         for r in pkg_resources.parse_requirements(
-            open(os.path.join(os.path.dirname(__file__), "requirements.txt"))
+            Path(__file__).with_name("requirements.txt").open()
         )
     ],
     entry_points={


### PR DESCRIPTION
I believe[ this commit in whisper](https://github.com/openai/whisper/commit/8bc8860694949db53c42ba47ddc23786c2e02a8b) addresses the issue of installing whisper-at described in #2 

I simply tried to copy over all the changes in the whisper update. With this update I was successfully able to install on Mac intel using python version 3.10 and 3.11.3.